### PR TITLE
issues on comparisons/computations using the 'relrm' relative movement values…

### DIFF
--- a/pyfMRIqc.py
+++ b/pyfMRIqc.py
@@ -487,9 +487,9 @@ def process(niifile, motionfile, maskthresh, maskniifile, outputdirectory, fname
         relrm = np.diff(rm, axis=1)
 
         # get thrtesholds:
-        nrrm01 = rm[np.where(rm > .1)]
-        nrrm05 = rm[np.where(rm > .5)]
-        nrrmv = rm[np.where(rm > voxelsize)]
+        nrrm01 = relrm[np.where(relrm > .1)]
+        nrrm05 = relrm[np.where(relrm > .5)]
+        nrrmv = relrm[np.where(relrm > voxelsize)]
 
     # create nifti files
     # --------------------


### PR DESCRIPTION
Had a chat with Brendan. Calculations at lines 490 - 492 should take 'relrm' instead of 'rm' (because it should be the 'relative movement' that is to be compared with, rather than the absolute movement?)... 